### PR TITLE
refactor: stricter lint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stricter lint rules - [68](https://github.com/dartoos-dev/flutter_brand_palettes/issues/68).
 
 ## [0.3.1] - 2021-05-24
 ### Added

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:lint/analysis_options_package.yaml
 linter:
   rules:
-    # Always await, intentionally not await
+    # Always await.
     unawaited_futures: true
+    # Make constructors the first thing in every class
+    sort_constructors_first: true
+    # Good packages document everything
+    public_member_api_docs: true


### PR DESCRIPTION
Add the following rules:    
- sort_constructors_first: true - make constructors the first thing in every class.
- public_member_api_docs: true - good packages document everything.
